### PR TITLE
Update Node.js version in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@
       runs-on: ubuntu-latest
       strategy:
         matrix:
-          node-version: [20.x, 22.x]
+          node-version: [24]
       steps:
         - uses: actions/checkout@v5
         - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
CI configuration update:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL19-R19): Changed the Node.js version matrix from `[20.x, 22.x]` to `[24]`, so CI jobs now run only on Node.js 24.