### PR TITLE
Update Node.js version from 20 to 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,5 +15,5 @@ inputs:
     description: 'Location to an allow list of target URL entries.'
     required: false
 runs:
-  using: 'node20'
+  using: node24
   main: 'dist/index.js'


### PR DESCRIPTION
This pull request updates the Node.js runtime version used by the GitHub Action. The action now runs on Node.js 24 instead of Node.js 20.